### PR TITLE
Refresh alpha from master and preserve previous alpha work

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,3 +1,8 @@
+branches:
+  - master
+  - name: alpha
+    prerelease: true
+
 plugins:
   - semantic-release-gitmoji
   - - "@semantic-release/npm"

--- a/Packages/com.nekometer.esnya.esnya-osakana-shader/package.json
+++ b/Packages/com.nekometer.esnya.esnya-osakana-shader/package.json
@@ -3,7 +3,7 @@
   "displayName": "Osakana Shader",
   "version": "1.0.0",
   "private": true,
-  "description": "Shader collection for Unity built-in shading. Tested with Unity 2018.4.20f1.",
+  "description": "Shader collection for Unity built-in shading. Tested with Unity 2022.3.22f1.",
   "keywords": [
     "Unity",
     "ShaderLab",
@@ -20,5 +20,6 @@
   "license": "MIT",
   "author": {
     "name": "esnya"
-  }
+  },
+  "unity": "2022.3"
 }

--- a/Packages/com.nekometer.esnya.esnya-pbr-shader/Editor/EsnyaUnityShaders.Editor.asmdef
+++ b/Packages/com.nekometer.esnya.esnya-pbr-shader/Editor/EsnyaUnityShaders.Editor.asmdef
@@ -9,6 +9,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": []
 }

--- a/Packages/com.nekometer.esnya.esnya-pbr-shader/package.json
+++ b/Packages/com.nekometer.esnya.esnya-pbr-shader/package.json
@@ -21,5 +21,5 @@
   "author": {
     "name": "esnya"
   },
-  "unity": "2019.4"
+  "unity": "2022.3"
 }

--- a/Packages/com.nekometer.esnya.esnya-toon-shader/package.json
+++ b/Packages/com.nekometer.esnya.esnya-toon-shader/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "com.nekometer.esnya.esnya-pbr-shader",
+  "name": "com.nekometer.esnya.esnya-toon-shader",
   "displayName": "Esnya PBR Shader",
   "version": "1.0.0",
   "private": true,
@@ -21,5 +21,5 @@
   "author": {
     "name": "esnya"
   },
-  "unity": "2019.4"
+  "unity": "2022.3"
 }

--- a/Packages/com.nekometer.esnya.esnya-unity-shaders/package.json
+++ b/Packages/com.nekometer.esnya.esnya-unity-shaders/package.json
@@ -3,7 +3,7 @@
   "displayName": "Esnya Unity Shaders",
   "version": "1.0.0",
   "private": true,
-  "description": "Shader collection for Unity built-in pipeline.",
+  "description": "Shader collection for Unity built-in pipeline. Tested with Unity 2022.3.22f1.",
   "keywords": [
     "Unity",
     "ShaderLab",
@@ -21,5 +21,5 @@
   "author": {
     "name": "esnya"
   },
-  "unity": "2019.4"
+  "unity": "2022.3"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Esnya Unity Shaders
-Shader collection for Unity built-in shading. Tested with Unity 2018.4.20f1.
+Shader collection for Unity built-in shading. Tested with Unity 2022.3.22f1.
 
 ([Japanese](#Japanese))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -984,11 +984,11 @@
       "link": true
     },
     "node_modules/com.nekometer.esnya.esnya-pbr-shader": {
-      "resolved": "Packages/com.nekometer.esnya.esnya-toon-shader",
+      "resolved": "Packages/com.nekometer.esnya.esnya-pbr-shader",
       "link": true
     },
     "node_modules/com.nekometer.esnya.esnya-toon-shader": {
-      "resolved": "Packages/com.nekometer.esnya.esnya-pbr-shader",
+      "resolved": "Packages/com.nekometer.esnya.esnya-toon-shader",
       "link": true
     },
     "node_modules/com.nekometer.esnya.esnya-unity-shaders": {
@@ -7271,12 +7271,12 @@
       "license": "MIT"
     },
     "Packages/com.nekometer.esnya.esnya-pbr-shader": {
-      "name": "com.nekometer.esnya.esnya-toon-shader",
+      "name": "com.nekometer.esnya.esnya-pbr-shader",
       "version": "1.0.0",
       "license": "MIT"
     },
     "Packages/com.nekometer.esnya.esnya-toon-shader": {
-      "name": "com.nekometer.esnya.esnya-pbr-shader",
+      "name": "com.nekometer.esnya.esnya-toon-shader",
       "version": "1.0.0",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EsnyaUnityShaders",
   "version": "2.6.1",
   "private": true,
-  "description": "Shader collection for Unity built-in shading. Tested with Unity 2018.4.20f1.",
+  "description": "Shader collection for Unity built-in shading. Tested with Unity 2022.3.22f1.",
   "keywords": [
     "Unity",
     "ShaderLab",
@@ -11,11 +11,11 @@
   ],
   "homepage": "https://github.com/esnya/EsnyaUnityShaders#readme",
   "bugs": {
-    "url": "https://github.com/esnya/EsnyaUnityTools/issues"
+    "url": "https://github.com/esnya/EsnyaUnityShaders/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/esnya/EsnyaUnityTools.git"
+    "url": "git+https://github.com/esnya/EsnyaUnityShaders.git"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- preserve the previous `alpha` state on `codex/alpha-snapshot-20260409`
- recreate `alpha` from the repository default line (`master`/`main`)
- carry the preserved alpha work forward through a reviewable PR

## Why
The old `alpha` branch had accumulated in-progress work directly on the branch. This PR makes `alpha` reviewable again while keeping the previous branch state intact.

## Validation
- branch pointers updated so `alpha` now starts from the primary branch
- previous `alpha` history preserved on `codex/alpha-snapshot-20260409`